### PR TITLE
Automated gratitude board updates

### DIFF
--- a/fetch_tweets.py
+++ b/fetch_tweets.py
@@ -51,5 +51,9 @@ for tweet in r.json():
 		new_grats += "* [%s %d%s, %d](https://twitter.com/DeviCatOutlet/status/%s)\n" % (
 			date.strftime("%B"), date.day, suffix, date.year, tweet["id_str"])
 
-with open("gratitudeboard.md", "w") as f:
-	f.write(grats_header + "Twitch Gratitude Board\n\n" + new_grats + "\n".join(grats_lines) + "\n")
+if new_grats:
+	with open("gratitudeboard.md", "w") as f:
+		f.write(grats_header + "Twitch Gratitude Board\n\n" + new_grats + "\n".join(grats_lines) + "\n")
+	print("Updated.")
+else:
+	print("No new tweets.")

--- a/fetch_tweets.py
+++ b/fetch_tweets.py
@@ -1,0 +1,55 @@
+import base64
+import requests
+import datetime
+
+# Fetch up Twitter credentials from Mustard Mine if available
+# If not, create a config.py with the necessary IDs.
+import sys
+sys.path.append("../mustard-mine")
+try: import config
+except ImportError: import config_sample as config
+
+# TODO: URL-encode as needed
+credentials = config.TWITTER_CLIENT_ID + ":" + config.TWITTER_CLIENT_SECRET
+credentials = base64.b64encode(credentials.encode("ascii")).decode("ascii")
+
+# Load up the most recent entries on the web site
+grab_next = False
+last_id = None
+with open("gratitudeboard.md") as f:
+	data = f.read()
+	grats_header, grats_lines = data.split("Twitch Gratitude Board", 1)
+	grats_lines = [line for line in grats_lines.split("\n") if line]
+	# sscanf(line, "%*shttps://twitter.com/DeviCatOutlet/status/%s)", last_id)
+	last_id = grats_lines[0].split("https://twitter.com/DeviCatOutlet/status/")[1].split(")")[0]
+print("Starting from:", last_id)
+r = requests.post("https://api.twitter.com/oauth2/token",
+	data={"grant_type": "client_credentials"},
+	headers={"Authorization": "Basic "+credentials})
+r.raise_for_status()
+credentials = r.json()
+if credentials["token_type"] != "bearer":
+	raise ValueError("Shouldn't happen")
+credentials = credentials["access_token"]
+r = requests.get("https://api.twitter.com/1.1/statuses/user_timeline.json",
+	params={"screen_name": "devicatoutlet", "count": 200, "trim_user": 1,
+	"since_id": last_id, "include_rts": 0, "exclude_replies": 1, "tweet_mode": "extended"},
+	headers={"Authorization": "Bearer "+credentials})
+if r.status_code != 200:
+	print(r.json())
+	r.raise_for_status()
+
+new_grats = ""
+
+for tweet in r.json():
+	if "Gratitude Board" in tweet["full_text"]:
+		print(tweet["created_at"] + " " + "https://twitter.com/DeviCatOutlet/status/" + tweet["id_str"])
+		print(tweet["full_text"].replace("\n", r"\n"))
+		print()
+		date = datetime.datetime.strptime(tweet["created_at"], "%a %b %d %H:%M:%S %z %Y")
+		suffix = {1: "st", 2: "nd", 3: "rd", 21: "st", 22: "nd", 23: "rd"}.get(date.day, "th")
+		new_grats += "* [%s %d%s, %d](https://twitter.com/DeviCatOutlet/status/%s)\n" % (
+			date.strftime("%B"), date.day, suffix, date.year, tweet["id_str"])
+
+with open("gratitudeboard.md", "w") as f:
+	f.write(grats_header + "Twitch Gratitude Board\n\n" + new_grats + "\n".join(grats_lines) + "\n")

--- a/gratitudeboard.md
+++ b/gratitudeboard.md
@@ -11,6 +11,7 @@
 
 ## Twitch Gratitude Board
 
+* [May 14th, 2018](https://twitter.com/DeviCatOutlet/status/995838919768969216)
 * [May 13th, 2018](https://twitter.com/DeviCatOutlet/status/995475391333781504)
 * [May 10th, 2018](https://twitter.com/DeviCatOutlet/status/994385274179391489)
 * [May 8th, 2018](https://twitter.com/DeviCatOutlet/status/993661349849980929)

--- a/gratitudeboard.md
+++ b/gratitudeboard.md
@@ -11,13 +11,10 @@
 
 ## Twitch Gratitude Board
 
-
-
-
-
-
-
-
+* [May 13th, 2018](https://twitter.com/DeviCatOutlet/status/995475391333781504)
+* [May 10th, 2018](https://twitter.com/DeviCatOutlet/status/994385274179391489)
+* [May 8th, 2018](https://twitter.com/DeviCatOutlet/status/993661349849980929)
+* [May 7th, 2018](https://twitter.com/DeviCatOutlet/status/993485608533266432)
 * [May 5th, 2018](https://twitter.com/DeviCatOutlet/status/992936698765041664)
 * [May 3rd, 2018](https://twitter.com/DeviCatOutlet/status/992213881669013504)
 * [May 2nd, 2018](https://twitter.com/DeviCatOutlet/status/991857667567181824)
@@ -38,8 +35,3 @@
 * [April 9th, 2018](https://twitter.com/DeviCatOutlet/status/983516329289412608)
 * [April 8th, 2018](https://twitter.com/DeviCatOutlet/status/983152886350827520)
 * [April 7th, 2018](https://twitter.com/DeviCatOutlet/status/982792374865801216)
-
-
-
-
-


### PR DESCRIPTION
This script downloads Devi's tweets and automatically updates the Gratitude Board page - just run it, commit, push. (I could make it commit and push too, but it's safer not to.)

It requires Twitter dev credentials, which don't get committed. One way is to simply have me run the script, since I have a separate project (MustardMine) which has such credentials; alternatively, anyone who wants to run it simply needs to go and register an app (doesn't cost anything, you just key in the details and get the keys).

Is this something that's wanted?